### PR TITLE
AbstractMeasure method

### DIFF
--- a/src/distribution_measure.jl
+++ b/src/distribution_measure.jl
@@ -17,6 +17,7 @@ struct DistributionMeasure{F<:VariateForm,S<:ValueSupport,D<:Distribution{F,S}} 
     d::D
 end
 
+@inline MeasureBase.AbstractMeasure(m::AbstractMeasure) = m
 
 @inline MeasureBase.AbstractMeasure(d::Distribution) = DistributionMeasure(d)
 


### PR DESCRIPTION
This adds a method
```julia
@inline MeasureBase.AbstractMeasure(m::AbstractMeasure) = m
```

With this, every time Tilde sees a `x ~ rhs`, it can call `AbstractMeasure(rhs)`, allowing measures and distributions to work in the same way.